### PR TITLE
Fix crash

### DIFF
--- a/nicechart.py
+++ b/nicechart.py
@@ -200,8 +200,8 @@ class NiceChart(inkex.Effect):
 		svg = self.document.getroot()
 		
 		# Get the page attibutes:
-		width  = inkex.unittouu(svg.get('width'))
-		height = inkex.unittouu(svg.attrib['height'])
+		width  = self.unittouu(svg.get('width'))
+		height = self.unittouu(svg.attrib['height'])
 		
 		# Create a new layer.
 		layer = inkex.etree.SubElement(svg, 'g')


### PR DESCRIPTION
In Inkscape 0.91, unittouu / uutounit have been moved to the inkex.Effect class, see Release notes: http://wiki.inkscape.org/wiki/index.php/Release_notes/0.91 . It takes a unit in the call to the function, too, but I think in the case of this extension, that can be left out (fallback is px). A user can resize a rendered chart as needed easily.